### PR TITLE
Use --filter=blob:none to clone CPython faster

### DIFF
--- a/scripts/benchmarks/setup.sh
+++ b/scripts/benchmarks/setup.sh
@@ -4,4 +4,4 @@
 # Setup the CPython repository to enable benchmarking.
 ###
 
-git clone --branch 3.10 https://github.com/python/cpython.git crates/ruff/resources/test/cpython
+git clone --branch 3.10 https://github.com/python/cpython.git crates/ruff/resources/test/cpython --filter=blob:none


### PR DESCRIPTION
```console
# Before
scripts/benchmarks/setup.sh  72,98s user 9,59s system 11% cpu 11:31,73 total
# After
scripts/benchmarks/setup.sh  10,70s user 2,77s system 6% cpu 3:33,95 total
```